### PR TITLE
hpc: update rv install script to use fr_page_list_len=256

### DIFF
--- a/hpc/rl810_rv_install.sh
+++ b/hpc/rl810_rv_install.sh
@@ -81,6 +81,6 @@ make -j"$(nproc)"
 sudo make install
 popd
 
-sudo modprobe rv
+sudo modprobe rv fr_page_list_len=256
 
 echo "Installation complete!"


### PR DESCRIPTION
update rv install script to use fr_page_list_len=256

We will keep loading rv like this until we figure out a cleaner way to set it with globals (if possible).