### PR TITLE
provider: Add patch to initialize shadow to odd and disable empty check for polling CQs

### DIFF
--- a/provider-irdma/rdma-core-v59/0008-irdma-Initialize-shadow-to-odd-and-disable-empty-che.patch
+++ b/provider-irdma/rdma-core-v59/0008-irdma-Initialize-shadow-to-odd-and-disable-empty-che.patch
@@ -1,0 +1,97 @@
+From 5f5280a973f2b13201bd5505151963dca6c81784 Mon Sep 17 00:00:00 2001
+From: Ted Shaowang <shaowang@google.com>
+Date: Tue, 16 Jun 2026 18:40:58 +0000
+Subject: [PATCH] irdma: Initialize shadow to odd and disable empty check for
+ polling CQs
+
+The hardware CQ shadow area is updated using an odd value masking logic.
+To avoid triggering a hardware translation bug, the driver implements a
+workaround that avoids writing even values to the shadow area.
+
+This patch makes two improvements to the CQ shadow area logic:
+1. Initializes the shadow area to cq_size - 1 (which is guaranteed to be an
+   odd value) rather than 0 during CQ creation. This ensures the hardware
+   never sees an even shadow value on the very first update.
+2. Disables the CQ empty check (irdma_cq_empty) during fast-path polling
+   for applications that do not use CQ interrupts (channel == NULL). This
+   safely bypasses the even value shadow update restriction for CQs that
+   are strictly busy-polling.
+
+Signed-off-by: Ted Shaowang <shaowang@google.com>
+---
+ providers/irdma/uk.c     | 8 ++++++--
+ providers/irdma/user.h   | 2 ++
+ providers/irdma/uverbs.c | 1 +
+ 3 files changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/providers/irdma/uk.c b/providers/irdma/uk.c
+index a89d8063..cfbf900d 100644
+--- a/providers/irdma/uk.c
++++ b/providers/irdma/uk.c
+@@ -1593,7 +1593,7 @@ int irdma_uk_cq_poll_cmpl(struct irdma_cq_uk *cq,
+ 				IRDMA_RING_MOVE_HEAD_NOCHECK(cq->cq_ring);
+ 				IRDMA_RING_MOVE_TAIL(cq->cq_ring);
+ 				/* Avoid translation issue by never setting shadow to even value unless the CQ is empty. */
+-				if (IRDMA_RING_CURRENT_HEAD(cq->cq_ring) & 1 || irdma_cq_empty(cq)) {
++				if (IRDMA_RING_CURRENT_HEAD(cq->cq_ring) & 1 || (cq->enable_cq_empty_check && irdma_cq_empty(cq))) {
+ 					set_64bit_val(cq->shadow_area, 0,
+ 						      IRDMA_RING_CURRENT_HEAD(cq->cq_ring));
+ 				}
+@@ -1696,7 +1696,7 @@ exit:
+ 		if (!cq->avoid_mem_cflct && ext_valid)
+ 			IRDMA_RING_MOVE_TAIL(cq->cq_ring);
+ 		/* Avoid translation issue by never setting shadow to even value unless the CQ is empty. */
+-		if (IRDMA_RING_CURRENT_HEAD(cq->cq_ring) & 1 || irdma_cq_empty(cq)) {
++		if (IRDMA_RING_CURRENT_HEAD(cq->cq_ring) & 1 || (cq->enable_cq_empty_check && irdma_cq_empty(cq))) {
+ 			set_64bit_val(cq->shadow_area, 0,
+ 			      IRDMA_RING_CURRENT_HEAD(cq->cq_ring));
+ 		}
+@@ -2222,9 +2222,13 @@ int irdma_uk_cq_init(struct irdma_cq_uk *cq, struct irdma_cq_uk_init_info *info)
+ 	cq->cq_ack_db = info->cq_ack_db;
+ 	cq->shadow_area = info->shadow_area;
+ 	cq->avoid_mem_cflct = info->avoid_mem_cflct;
++	cq->enable_cq_empty_check = info->enable_cq_empty_check;
+ 	IRDMA_RING_INIT(cq->cq_ring, cq->cq_size);
+ 	cq->polarity = 1;
+ 
++	__u32 initial_shadow = cq->cq_size - 1;
++	set_64bit_val(cq->shadow_area, 0, initial_shadow);
++
+ 	return 0;
+ }
+ 
+diff --git a/providers/irdma/user.h b/providers/irdma/user.h
+index f7be5d31..65be3dff 100644
+--- a/providers/irdma/user.h
++++ b/providers/irdma/user.h
+@@ -643,6 +643,7 @@ struct irdma_cq_uk {
+ 	struct irdma_ring cq_ring;
+ 	__u8 polarity;
+ 	bool avoid_mem_cflct:1;
++	bool enable_cq_empty_check:1;
+ };
+ 
+ struct irdma_qp_uk_init_info {
+@@ -682,6 +683,7 @@ struct irdma_cq_uk_init_info {
+ 	__u32 cq_size;
+ 	__u32 cq_id;
+ 	bool avoid_mem_cflct;
++	bool enable_cq_empty_check;
+ };
+ 
+ void irdma_print_cqes(struct irdma_cq_uk *cq);
+diff --git a/providers/irdma/uverbs.c b/providers/irdma/uverbs.c
+index f9bf98da..ab432b84 100644
+--- a/providers/irdma/uverbs.c
++++ b/providers/irdma/uverbs.c
+@@ -814,6 +814,7 @@ static struct ibv_cq_ex *ucreate_cq(struct ibv_context *context,
+ 	iwucq->verbs_cq.cq.cqe = ncqe;
+ 	if (cqe_64byte_ena)
+ 		info.avoid_mem_cflct = true;
++	info.enable_cq_empty_check = (attr_ex->channel != NULL);
+ 	info.cqe_alloc_db = (__u32 *)((__u8 *)iwvctx->db + IRDMA_DB_CQ_OFFSET);
+ 	irdma_uk_cq_init(&iwucq->cq, &info);
+ 	pthread_mutex_lock(&sigusr1_wait_mutex);
+-- 
+2.54.0.1136.gdb2ca164c4-goog
+


### PR DESCRIPTION
The hardware CQ shadow area is updated using an odd value masking logic.
To avoid triggering a hardware translation bug, the driver implements a
workaround that avoids writing even values to the shadow area.

This patch makes two improvements to the CQ shadow area logic:
1. Initializes the shadow area to cq_size - 1 (which is guaranteed to be an
   odd value) rather than 0 during CQ creation. This ensures the hardware
   never sees an even shadow value on the very first update.
2. Disables the CQ empty check (irdma_cq_empty) during fast-path polling
   for applications that do not use CQ interrupts (channel == NULL). This
   safely bypasses the even value shadow update restriction for CQs that
   are strictly busy-polling.